### PR TITLE
Replace SQLite with MySQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "hyperswitch": "^0.12.7",
     "jsonwebtoken": "^8.5.1",
     "mediawiki-title": "^0.7.2",
-    "restbase-mod-table-cassandra": "^1.2.1",
+    "restbase-mod-table-mysql": "^0.1.0",
     "semver": "latest",
     "service-runner": "^2.7.3",
     "uuid": "^3.3.3"

--- a/sys/table.js
+++ b/sys/table.js
@@ -9,8 +9,11 @@ module.exports = (options) => {
     options.conf.backend = options.conf.backend || 'cassandra';
     options.log = options.logger.log.bind(options.logger);
 
-    if (options.conf.backend !== 'cassandra' &&
-            options.conf.backend !== 'sqlite') {
+    if (
+        options.conf.backend !== 'cassandra' &&
+        options.conf.backend !== 'mysql' &&
+        options.conf.backend !== 'sqlite'
+    ) {
         throw new Error(`Unsupported backend version specified: ${options.conf.backend}`);
     }
 


### PR DESCRIPTION
**\*주의\*** 이 브랜치는 https://www.npmjs.com/package/restbase-mod-table-mysql 패키지가 정상적으로 퍼블리시되었을 것을 가정하고 있습니다. 그렇지 않은 동안 테스트가 필요하거나 Travis CI의 테스트 결과가 필요한 경우에는 [1.1.1-mysql-test](https://github.com/femiwiki/restbase/tree/1.1.1-mysql-test) 브랜치를 사용해 주세요.<hr/>

https://github.com/femiwiki/femiwiki/issues/86 관련, RESTBase의 `package.json`에 의존성으로 `restbase-mod-table-mysql`를 추가하고, 해당 모듈을 선택할 수 있도록 변경하였습니다

머지 후에는 이 리포지토리를 [https://www.npmjs.com/package/@femiwiki/restbase](https://www.npmjs.com/package/@femiwiki/restbase)로 **꼭** 퍼블리시해 주세요!